### PR TITLE
add images downloading via `CLI` for `seeds.rb`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "yadisk"
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yadisk (0.2.0)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -278,6 +279,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  yadisk
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Медиа-сервис для поиска эскизов тату и тату мастеров
 
-1. Клонируйте репозиторий
+1. Склонируйте репозиторий
 
 ```bash
 git clone https://github.com/HSEADC/B21DZ09-L3-Project-03.git
 ```
 
-2. Зайдите в папку проекта
+2. Перейдите в папку проекта
 
 ```bash
 cd B21DZ09-L3-Project-03
@@ -14,7 +14,7 @@ cd B21DZ09-L3-Project-03
 
 3. Установите зависимости (gems)
 
-```ruby
+```bash
 bundle install
 ```
 
@@ -24,18 +24,52 @@ bundle install
 rails db:migrate
 ```
 
-5. Скачайте [изображения с тату](https://disk.yandex.ru/d/PTdfE03I45aN2w) и разместите их в `public/autoupload/tattoos`
+5. Скачайте вручную [изображения с тату](https://disk.yandex.ru/d/PTdfE03I45aN2w) и разместите их в `public/autoupload/tattoos` или сделайте это через `*CLI`
 
-
-
-7. Наполните сидами базу данных
+6. Наполните сидами базу данных
 
 ```ruby
 rails db:seed
 ```
 
-7. Запустите сервер разработки
+7. Запустите сервер разработки [с компиляцией `tailwind-css` классов]
 
 ```ruby
 bin/dev
 ```
+
+<br/>
+<br/>
+
+<details>
+<summary>Скачать изображения с тату через *CLI:</summary>
+
+<br/>
+
+1. Установка пакета `unzip` для `Linux`
+```ruby
+sudo apt-get install unzip
+```
+для `MacOS`
+
+```ruby
+brew install unzip
+```
+
+2. Загрузка `.zip` архива с помощью gem `yadisk`
+```bash
+yadisk https://disk.yandex.ru/d/t0zdYm6sBbULlg public/autoupload
+```
+
+3. Извлечение данных из `.zip` архива в `public/autoupload`
+```bash
+unzip public/autoupload/tattoos.zip -d public/autoupload
+```
+
+4. Удаление `.zip` архива
+```bash
+rm public/autoupload/tattoos.zip
+```
+
+</details>
+<br/>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ bin/dev
 
 <br/>
 
-1. Установка пакета `unzip` для `Linux`
+1. Установите пакет `unzip` для `Linux`
 ```ruby
 sudo apt-get install unzip
 ```
@@ -56,17 +56,17 @@ sudo apt-get install unzip
 brew install unzip
 ```
 
-2. Загрузка `.zip` архива с помощью gem `yadisk`
+2. Загрузите `.zip` архив с помощью gem `yadisk`
 ```bash
 yadisk https://disk.yandex.ru/d/t0zdYm6sBbULlg public/autoupload
 ```
 
-3. Извлечение данных из `.zip` архива в `public/autoupload`
+3. Извлеките данные из `.zip` архива в `public/autoupload`
 ```bash
 unzip public/autoupload/tattoos.zip -d public/autoupload
 ```
 
-4. Удаление `.zip` архива
+4. Удалите `.zip` архив
 ```bash
 rm public/autoupload/tattoos.zip
 ```

--- a/README.md
+++ b/README.md
@@ -50,23 +50,28 @@ bin/dev
 ```ruby
 sudo apt-get install unzip
 ```
-для `MacOS`
 
+для `MacOS`
 ```ruby
 brew install unzip
 ```
 
-2. Загрузите `.zip` архив с помощью gem `yadisk`
+2. Создайте папку `autoupload` в `/public`
+```bash
+mkdir public/autoupload
+```
+
+3. Загрузите `.zip` архив с помощью gem `yadisk`
 ```bash
 yadisk https://disk.yandex.ru/d/t0zdYm6sBbULlg public/autoupload
 ```
 
-3. Извлеките данные из `.zip` архива в `public/autoupload`
+4. Извлеките данные из `.zip` архива в `public/autoupload`
 ```bash
 unzip public/autoupload/tattoos.zip -d public/autoupload
 ```
 
-4. Удалите `.zip` архив
+5. Удалите `.zip` архив
 ```bash
 rm public/autoupload/tattoos.zip
 ```

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,13 +17,13 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :masters do
       resources :tattoos
-      # resources :feedbacks
+      #? resources :feedbacks
     end
 
     resources :masters
     resources :tattoos
     resources :subscriptions
-    # resources :feedbacks, except: [:show]
+    #? resources :feedbacks, except: [:show]
   end
 
   resources :masters do


### PR DESCRIPTION
## I have added `yadisk` gem and detailed instructions to the documentation

<details>
<summary>Скачать изображения с тату через *CLI:</summary>

<br/>

1. Установите пакет `unzip` для `Linux`
```ruby
sudo apt-get install unzip
```

для `MacOS`
```ruby
brew install unzip
```

2. Создайте папку `autoupload` в `/public`
```bash
mkdir public/autoupload
```

3. Загрузите `.zip` архив с помощью gem `yadisk`
```bash
yadisk https://disk.yandex.ru/d/t0zdYm6sBbULlg public/autoupload
```

4. Извлеките данные из `.zip` архива в `public/autoupload`
```bash
unzip public/autoupload/tattoos.zip -d public/autoupload
```

5. Удалите `.zip` архив
```bash
rm public/autoupload/tattoos.zip
```

</details>